### PR TITLE
fix: signal channel should be buffered

### DIFF
--- a/pkg/shutdown/shutdown.go
+++ b/pkg/shutdown/shutdown.go
@@ -11,7 +11,7 @@ func init() {
 	signal.Notify(signals, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 }
 
-var signals = make(chan os.Signal)
+var signals = make(chan os.Signal, 1)
 
 func Chan() <-chan struct{} {
 	shutdown := make(chan struct{})

--- a/pkg/shutdown/shutdown_test.go
+++ b/pkg/shutdown/shutdown_test.go
@@ -9,6 +9,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestBuffered(t *testing.T) {
+	process, err := os.FindProcess(os.Getpid())
+	assert.NoError(t, err)
+
+	go func() {
+		time.Sleep(time.Millisecond)
+		err := process.Signal(os.Interrupt)
+		assert.NoError(t, err)
+	}()
+
+	time.Sleep(time.Millisecond * 10)
+	select {
+	case <-Chan():
+	case <-time.After(time.Second):
+		assert.Fail(t, "shutdown never happened")
+	}
+}
+
 func TestChan(t *testing.T) {
 	testShutdown(t, Chan())
 }


### PR DESCRIPTION
shutdown uses an unbuffered channel for os.Signal. Recommendation is to use a buffered channel. Otherwise, you may miss a signal.